### PR TITLE
Handle new envoy-resources and reassignment before expiration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Coordinates Envoy-Resource registrations in zones by watching for changes, expiring expected
+resources in zones, and producing events to notify other subsystems about changes to zone
+composition.

--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -1,0 +1,93 @@
+substitutions:
+  _GCS_CACHE_BUCKET: salus-cache
+  _SALUS_PROJECT: salus-telemetry-zone-management
+
+steps:
+
+    # This is ugly because of
+    # https://github.com/GoogleContainerTools/jib/issues/1500#issuecomment-466207421
+  - id: FIX_DOCKER
+    name: gcr.io/cloud-builders/mvn
+    waitFor: ['-']
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - # Links the Docker config to /root/.docker/config.json so that Jib picks it up.
+      # Note that this is only a temporary workaround.
+      # See https://github.com/GoogleContainerTools/jib/pull/1479.
+      |
+      mkdir .docker &&
+      ln -vs $$HOME/.docker/config.json .docker/config.json
+    volumes:
+    - name: user.home
+      path: /root
+
+  # Pull down settings file for Artifactory settings
+  - id: GET_SETTINGS
+    name: 'gcr.io/cloud-builders/gsutil'
+    waitFor: ['-']
+    args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
+
+  # Load the cached files from GCS if they exist.
+  - id: PULL_DOWN_CACHE
+    waitFor: ['-']
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      (
+        gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+        tar -xzf /tmp/m2-cache.tar.gz
+      ) || echo 'Cache not found'
+    volumes:
+    - name: user.home
+      path: /root
+
+  - id: DEPLOY
+    name: 'gcr.io/cloud-builders/mvn'
+    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
+    volumes:
+    - name: user.home
+      path: /root
+
+  - id: COMPILE_AND_PUSH_CONTAINER
+    name: 'gcr.io/cloud-builders/mvn'
+    env:
+    - 'SHORT_SHA=$SHORT_SHA'
+    args:
+    - compile
+    # Runs the Jib build by using the latest version of the plugin.
+    # To use a specific version, configure the plugin in the pom.xml.
+    - jib:build
+    - "-B"
+    # Skip Tests since it happened in the previous test
+    - "-Dmaven.test.skip=true"
+    # Ensure we name the image correctly since its not in pom.xml
+    - "-Ddocker.image.prefix=gcr.io/$PROJECT_ID"
+    - "-s"
+    - .mvn/settings.xml
+    volumes:
+    - name: user.home
+      path: /root
+
+  # Saves the files to the GCS cache.
+  - id: PUSH_UP_CACHE
+    waitFor:
+    - COMPILE_AND_PUSH_CONTAINER
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    # Caches the local Maven repository.
+    args:
+    - -c
+    - |
+      set -ex
+      tar -czf /tmp/m2-cache.tar.gz .m2 &&
+      gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+    volumes:
+    - name: user.home
+      path: /root
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,54 @@
+substitutions:
+  _GCS_CACHE_BUCKET: salus-cache
+  _SALUS_PROJECT: salus-telemetry-zone-management
+
+steps:
+
+  # Pull down settings file for Artifactory settings
+  - id: GET_SETTINGS
+    name: 'gcr.io/cloud-builders/gsutil'
+    waitFor: ['-']
+    args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
+
+  # Load the cached files from GCS if they exist.
+  - id: PULL_DOWN_CACHE
+    waitFor: ['-']
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      (
+        gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+        tar -xzf /tmp/m2-cache.tar.gz
+      ) || echo 'Cache not found'
+    volumes:
+    - name: user.home
+      path: /root
+
+  - id: DEPLOY
+    name: 'gcr.io/cloud-builders/mvn'
+    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
+    volumes:
+    - name: user.home
+      path: /root
+
+  # Saves the files to the GCS cache.
+  - id: PUSH_UP_CACHE
+    waitFor:
+    - DEPLOY
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    # Caches the local Maven repository.
+    args:
+    - -c
+    - |
+      set -ex
+      tar -czf /tmp/m2-cache.tar.gz .m2 &&
+      gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+    volumes:
+    - name: user.home
+      path: /root
+

--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,6 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-    </dependency>
-    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <scope>runtime</scope>
@@ -60,6 +56,16 @@
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-model</artifactId>
       <version>0.1.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>spring-boot-starter-jdbc</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-jdbc</artifactId>
+          <groupId>org.springframework</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.rackspace.salus</groupId>
+    <artifactId>salus-app-base</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../salus-app-base</relativePath>
+  </parent>
+
+  <artifactId>salus-telemetry-zone-management</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-model</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-etcd-adapter</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.co.jemos.podam</groupId>
+      <artifactId>podam</artifactId>
+      <version>7.2.1.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>client-jar</id>
+            <goals><goal>jar</goal></goals>
+            <configuration>
+              <classifier>client</classifier>
+              <includes>
+                <include>**/web/model/**</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/src/main/java/com/rackspace/salus/zone_mgmt/ZoneManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/zone_mgmt/ZoneManagementApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.zone_mgmt;
+
+import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
+import com.rackspace.salus.telemetry.etcd.EnableEtcd;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@EnableSalusKafkaMessaging
+@EnableEtcd
+public class ZoneManagementApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(ZoneManagementApplication.class, args);
+  }
+}

--- a/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.zone_mgmt.services;
+
+import com.coreos.jetcd.Watch.Watcher;
+import com.coreos.jetcd.common.exception.EtcdException;
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorageListener;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
+import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ZoneWatchingService implements ZoneStorageListener {
+
+  private final ZoneStorage zoneStorage;
+  private final KafkaTemplate kafkaTemplate;
+  private final KafkaTopicProperties topicProperties;
+  private Watcher expectedZonesWatcher;
+
+  @Autowired
+  public ZoneWatchingService(ZoneStorage zoneStorage, KafkaTemplate kafkaTemplate,
+                             KafkaTopicProperties topicProperties) {
+    this.zoneStorage = zoneStorage;
+    this.kafkaTemplate = kafkaTemplate;
+    this.topicProperties = topicProperties;
+  }
+
+  @PostConstruct
+  public void start() {
+
+    zoneStorage.watchExpectedZones(this)
+        .thenAccept(watcher -> {
+          log.debug("Watching expected zones");
+          this.expectedZonesWatcher = watcher;
+        });
+
+  }
+
+  @PreDestroy
+  public void stop() {
+    if (expectedZonesWatcher != null) {
+      expectedZonesWatcher.close();
+      expectedZonesWatcher = null;
+    }
+  }
+
+  @Override
+  public void handleNewEnvoyResourceInZone(ResolvedZone resolvedZone) {
+    log.debug("Handling new envoy-resource in zone={}", resolvedZone);
+
+    //noinspection unchecked
+    kafkaTemplate.send(
+        topicProperties.getZones(),
+        buildMessageKey(resolvedZone),
+        new ZoneNewResourceEvent()
+            .setTenantId(resolvedZone.getTenantId())
+            .setZoneId(resolvedZone.getId())
+    );
+  }
+
+  private String buildMessageKey(ResolvedZone resolvedZone) {
+    return resolvedZone.isPublicZone() ?
+        resolvedZone.getId() :
+        String.join(":", resolvedZone.getTenantId(), resolvedZone.getId());
+  }
+
+  @Override
+  public void handleEnvoyResourceReassignedInZone(ResolvedZone resolvedZone, String fromEnvoyId,
+                                                  String toEnvoyId) {
+    log.debug("Handling new envoy-resource reassigned zone={} from={} to={}",
+        resolvedZone, fromEnvoyId, toEnvoyId);
+
+    //noinspection unchecked
+    kafkaTemplate.send(
+        topicProperties.getZones(),
+        buildMessageKey(resolvedZone),
+        new ZoneEnvoyOfResourceChangedEvent()
+            .setFromEnvoyId(fromEnvoyId)
+            .setToEnvoyId(toEnvoyId)
+            .setTenantId(resolvedZone.getTenantId())
+            .setZoneId(resolvedZone.getId())
+    );
+  }
+
+  @Override
+  public void handleExpectedZoneWatcherClosed(EtcdException e) {
+    // this is normal during application shutdown
+    log.debug("Observed closure while watching expected zones: {}", e.getMessage());
+  }
+}

--- a/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
@@ -22,8 +22,8 @@ import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorageListener;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
-import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
-import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
+import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +31,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+/**
+ * This class utilities {@link ZoneStorage} to register and react to etcd watches on the ranges
+ * of zone-related keys. It is essentially a mediator between etcd events and the production
+ * of kafka events for consumption by other microservices in Salus.
+ */
 @Service
 @Slf4j
 public class ZoneWatchingService implements ZoneStorageListener {
@@ -76,7 +81,7 @@ public class ZoneWatchingService implements ZoneStorageListener {
     kafkaTemplate.send(
         topicProperties.getZones(),
         buildMessageKey(resolvedZone),
-        new ZoneNewResourceEvent()
+        new NewResourceZoneEvent()
             .setTenantId(resolvedZone.getTenantId())
             .setZoneId(resolvedZone.getId())
     );
@@ -98,7 +103,7 @@ public class ZoneWatchingService implements ZoneStorageListener {
     kafkaTemplate.send(
         topicProperties.getZones(),
         buildMessageKey(resolvedZone),
-        new ZoneEnvoyOfResourceChangedEvent()
+        new ReattachedResourceZoneEvent()
             .setFromEnvoyId(fromEnvoyId)
             .setToEnvoyId(toEnvoyId)
             .setTenantId(resolvedZone.getTenantId())

--- a/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
@@ -55,7 +55,8 @@ public class ZoneWatchingService implements ZoneStorageListener {
         .thenAccept(watcher -> {
           log.debug("Watching expected zones");
           this.expectedZonesWatcher = watcher;
-        });
+        })
+        .join();
 
   }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,5 @@
+etcd:
+  url: http://localhost:2479
 server:
   port: 8084
 logging:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+server:
+  port: 8084
+logging:
+  level:
+    com.rackspace.salus.zone_mgmt: debug
+    com.rackspace.salus.telemetry.etcd: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  kafka:
+    producer:
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/src/test/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingServiceTest.java
+++ b/src/test/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingServiceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.zone_mgmt.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.coreos.jetcd.Watch.Watcher;
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
+import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ZoneWatchingServiceTest {
+
+  @Mock
+  KafkaTemplate kafkaTemplate;
+
+  @Mock
+  ZoneStorage zoneStorage;
+
+  @Mock
+  Watcher watcher;
+
+  @Test
+  public void testStart() {
+    when(zoneStorage.watchExpectedZones(any()))
+        .thenReturn(CompletableFuture.completedFuture(watcher));
+
+    KafkaTopicProperties topicProperties = new KafkaTopicProperties();
+    final ZoneWatchingService zoneWatchingService = new ZoneWatchingService(
+        zoneStorage, kafkaTemplate, topicProperties);
+
+    zoneWatchingService.start();
+
+    verify(zoneStorage).watchExpectedZones(same(zoneWatchingService));
+  }
+
+  @Test
+  public void handleNewEnvoyResourceInZone() {
+    KafkaTopicProperties topicProperties = new KafkaTopicProperties();
+    topicProperties.setZones("test.zones.json");
+    final ZoneWatchingService zoneWatchingService = new ZoneWatchingService(
+        zoneStorage, kafkaTemplate, topicProperties);
+
+    final ResolvedZone resolvedZone = new ResolvedZone()
+        .setTenantId("t-1")
+        .setId("z-1");
+
+    zoneWatchingService.handleNewEnvoyResourceInZone(resolvedZone);
+
+    //noinspection unchecked
+    verify(kafkaTemplate).send(
+        eq("test.zones.json"),
+        eq("t-1:z-1"),
+        eq(
+            new ZoneNewResourceEvent()
+                .setTenantId("t-1")
+                .setZoneId("z-1")
+        )
+    );
+
+    verifyNoMoreInteractions(kafkaTemplate);
+  }
+
+  @Test
+  public void handleEnvoyResourceReassignedInZone() {
+    KafkaTopicProperties topicProperties = new KafkaTopicProperties();
+    topicProperties.setZones("test.zones.json");
+    final ZoneWatchingService zoneWatchingService = new ZoneWatchingService(
+        zoneStorage, kafkaTemplate, topicProperties);
+
+    final ResolvedZone resolvedZone = new ResolvedZone()
+        .setTenantId("t-1")
+        .setId("z-1");
+
+    zoneWatchingService.handleEnvoyResourceReassignedInZone(resolvedZone, "e-1", "e-2");
+
+    //noinspection unchecked
+    verify(kafkaTemplate).send(
+        eq("test.zones.json"),
+        eq("t-1:z-1"),
+        eq(
+            new ZoneEnvoyOfResourceChangedEvent()
+                .setFromEnvoyId("e-1")
+                .setToEnvoyId("e-2")
+                .setTenantId("t-1")
+                .setZoneId("z-1")
+        )
+    );
+
+    verifyNoMoreInteractions(kafkaTemplate);
+
+  }
+}

--- a/src/test/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingServiceTest.java
+++ b/src/test/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingServiceTest.java
@@ -27,8 +27,8 @@ import com.coreos.jetcd.Watch.Watcher;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
-import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
-import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
+import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,9 +69,7 @@ public class ZoneWatchingServiceTest {
     final ZoneWatchingService zoneWatchingService = new ZoneWatchingService(
         zoneStorage, kafkaTemplate, topicProperties);
 
-    final ResolvedZone resolvedZone = new ResolvedZone()
-        .setTenantId("t-1")
-        .setId("z-1");
+    final ResolvedZone resolvedZone = ResolvedZone.createPrivateZone("t-1", "z-1");
 
     zoneWatchingService.handleNewEnvoyResourceInZone(resolvedZone);
 
@@ -80,7 +78,7 @@ public class ZoneWatchingServiceTest {
         eq("test.zones.json"),
         eq("t-1:z-1"),
         eq(
-            new ZoneNewResourceEvent()
+            new NewResourceZoneEvent()
                 .setTenantId("t-1")
                 .setZoneId("z-1")
         )
@@ -96,9 +94,7 @@ public class ZoneWatchingServiceTest {
     final ZoneWatchingService zoneWatchingService = new ZoneWatchingService(
         zoneStorage, kafkaTemplate, topicProperties);
 
-    final ResolvedZone resolvedZone = new ResolvedZone()
-        .setTenantId("t-1")
-        .setId("z-1");
+    final ResolvedZone resolvedZone = ResolvedZone.createPrivateZone("t-1", "z-1");
 
     zoneWatchingService.handleEnvoyResourceReassignedInZone(resolvedZone, "e-1", "e-2");
 
@@ -107,7 +103,7 @@ public class ZoneWatchingServiceTest {
         eq("test.zones.json"),
         eq("t-1:z-1"),
         eq(
-            new ZoneEnvoyOfResourceChangedEvent()
+            new ReattachedResourceZoneEvent()
                 .setFromEnvoyId("e-1")
                 .setToEnvoyId("e-2")
                 .setTenantId("t-1")


### PR DESCRIPTION
# Resolves

Part of
- https://jira.rax.io/browse/SALUS-263
- https://jira.rax.io/browse/SALUS-311

# What

This introduces just enough of the zone management application to
- watch when a new envoy-resource registers into the expected zone key range
- watch when a pre-existing envoy-resource re-registers with the same resource ID
- produces a corresponding zone event for each scenario

Detailed sequence diagrams were created to assist me in developing the code for this and corresponding monitor management changes (soon to be PR'ed):

https://one.rackspace.com/pages/viewpage.action?pageId=577472836#ExplicitPollerPickingDesign-DetailedSequenceDiagrams

# Depends on

- https://github.com/racker/salus-telemetry-etcd-adapter/pull/29

## How to test

New unit tests were created.