### PR TITLE
Renaming zoneId to zoneName to match Zone field naming

### DIFF
--- a/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
+++ b/src/main/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingService.java
@@ -83,14 +83,14 @@ public class ZoneWatchingService implements ZoneStorageListener {
         buildMessageKey(resolvedZone),
         new NewResourceZoneEvent()
             .setTenantId(resolvedZone.getTenantId())
-            .setZoneId(resolvedZone.getId())
+            .setZoneName(resolvedZone.getName())
     );
   }
 
   private String buildMessageKey(ResolvedZone resolvedZone) {
     return resolvedZone.isPublicZone() ?
-        resolvedZone.getId() :
-        String.join(":", resolvedZone.getTenantId(), resolvedZone.getId());
+        resolvedZone.getName() :
+        String.join(":", resolvedZone.getTenantId(), resolvedZone.getName());
   }
 
   @Override
@@ -107,7 +107,7 @@ public class ZoneWatchingService implements ZoneStorageListener {
             .setFromEnvoyId(fromEnvoyId)
             .setToEnvoyId(toEnvoyId)
             .setTenantId(resolvedZone.getTenantId())
-            .setZoneId(resolvedZone.getId())
+            .setZoneName(resolvedZone.getName())
     );
   }
 

--- a/src/test/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingServiceTest.java
+++ b/src/test/java/com/rackspace/salus/zone_mgmt/services/ZoneWatchingServiceTest.java
@@ -80,7 +80,7 @@ public class ZoneWatchingServiceTest {
         eq(
             new NewResourceZoneEvent()
                 .setTenantId("t-1")
-                .setZoneId("z-1")
+                .setZoneName("z-1")
         )
     );
 
@@ -107,7 +107,7 @@ public class ZoneWatchingServiceTest {
                 .setFromEnvoyId("e-1")
                 .setToEnvoyId("e-2")
                 .setTenantId("t-1")
-                .setZoneId("z-1")
+                .setZoneName("z-1")
         )
     );
 


### PR DESCRIPTION
# What

With the changes in https://github.com/racker/salus-telemetry-monitor-management/pull/29 the "id" fields in the zone events and `ResolvedZone` have been renamed in https://github.com/racker/salus-telemetry-model/pull/46 to "name" to be consistent.